### PR TITLE
feat: add poll liveness tracking for ALB health checks FGR3-9701

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @FigurePOS/veverka
+* @FigurePOS/spider
 
-/.github/ @FigurePOS/platform @FigurePOS/veverka
+/.github/ @FigurePOS/platform @FigurePOS/spider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+## [8.1.0] - 2026-06-04
+
+### Features
+
+* add poll liveness tracking for ALB `/ping` health checks (`isPollHealthy`, `secondsSincePollActivity`, etc.)
+* add optional `pollLivenessWatchdog` and `poll_liveness_stale` event
+* add `pollReceiveTimeoutMs` option (default `max(35000, waitTimeSeconds * 1000 + 5000)`)
 
 ## [8.0.0](https://github.com/FigurePOS/sqs-consumer-2/compare/v6.0.1...v8.0.0) (2025-12-29)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@figurepos/sqs-consumer",
-    "version": "8.0.0",
+    "version": "8.1.0",
     "description": "SQS Consumer",
     "scripts": {
         "build": "npm run clean && ./node_modules/.bin/tsc",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,10 @@
         "lint": "./node_modules/.bin/eslint '*/**/*.{js,json,ts}'",
         "lint:fix": "./node_modules/.bin/eslint '*/**/*.{js,json,ts}' --quiet --fix",
         "posttest": "npm run lint",
-        "prepublish": "npm run build",
-        "pretest": "npm run build",
+        "prepublishOnly": "npm run build",
         "prettier:check": "./node_modules/.bin/prettier --check '**/*.js' '**/*.json' '**/*.ts'",
         "prettier:fix": "./node_modules/.bin/prettier --write '**/*.js' '**/*.json' '**/*.ts'",
-        "release": "npm run build && ./node_modules/.bin/release-it",
+        "release": "./node_modules/.bin/release-it",
         "test": "mocha --recursive --full-trace --exit",
         "tsc": "./node_modules/.bin/tsc --noEmit",
         "watch": "tsc --watch"

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -355,13 +355,13 @@ export class Consumer extends EventEmitter {
     }
 
     private async receiveMessage(params: ReceiveMessageRequest): Promise<ReceiveMessageResult> {
-        this.pollLiveness.onPollStarted()
+        this.pollLiveness.markPollStarted()
         try {
             const result = await this.sqs.send(new ReceiveMessageCommand(params))
-            this.pollLiveness.onPollCompleted()
+            this.pollLiveness.markPollCompleted()
             return result
         } catch (err) {
-            this.pollLiveness.onPollCompleted()
+            this.pollLiveness.markPollCompleted()
             throw toSQSError(err, `SQS receive message failed: ${err.message}`)
         }
     }

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -13,12 +13,14 @@ import {
 import { EventEmitter } from "events"
 import { autoBind } from "./bind"
 import { SQSError, TimeoutError } from "./errors"
+import { DEFAULT_POLL_RECEIVE_TIMEOUT_MS, PollLiveness } from "./liveness"
 import {
     BatchProcessingResult,
     ConsumerOptions,
     Events,
     PendingMessage,
     PendingMessages,
+    PollLivenessWatchdogOptions,
     TimeoutResponse,
 } from "./types"
 import {
@@ -52,11 +54,14 @@ export class Consumer extends EventEmitter {
     private readonly sqs: SQSClient
     private readonly batchProcessingGroupFunction: ((batch: PendingMessage[]) => PendingMessage[][]) | null
     private readonly transformMessages: (messages: Message[]) => Message[]
+    private readonly pollLiveness: PollLiveness
+    private readonly pollLivenessWatchdog: PollLivenessWatchdogOptions | null
     private pendingMessages: PendingMessages
 
     private stopped: boolean
     private pollingStopped: boolean
     private heartbeatTimeout: NodeJS.Timeout
+    private pollLivenessWatchdogInterval: NodeJS.Timeout | null
 
     constructor(options: ConsumerOptions) {
         super()
@@ -80,7 +85,14 @@ export class Consumer extends EventEmitter {
         this.waitTimeSeconds = options.waitTimeSeconds || 20
         this.authenticationErrorTimeout = options.authenticationErrorTimeout || 10000
         this.pollingWaitTimeMs = options.pollingWaitTimeMs || 10
+        this.pollLivenessWatchdog = options.pollLivenessWatchdog ?? null
+        this.pollLivenessWatchdogInterval = null
         this.pendingMessages = []
+
+        const pollReceiveTimeoutMs =
+            options.pollReceiveTimeoutMs ??
+            Math.max(DEFAULT_POLL_RECEIVE_TIMEOUT_MS, this.waitTimeSeconds * 1000 + 5000)
+        this.pollLiveness = new PollLiveness(pollReceiveTimeoutMs)
 
         this.sqs =
             options.sqs ||
@@ -117,6 +129,22 @@ export class Consumer extends EventEmitter {
         return !this.stopped
     }
 
+    public getLastPollCompletedAt(): number {
+        return this.pollLiveness.getLastPollCompletedAt()
+    }
+
+    public secondsSincePollCompleted(): number {
+        return this.pollLiveness.secondsSincePollCompleted()
+    }
+
+    public secondsSincePollActivity(): number {
+        return this.pollLiveness.secondsSincePollActivity()
+    }
+
+    public isPollHealthy(maxStaleSeconds: number = 60): boolean {
+        return this.pollLiveness.isPollHealthy(maxStaleSeconds)
+    }
+
     public static create(options: ConsumerOptions): Consumer {
         return new Consumer(options)
     }
@@ -124,14 +152,17 @@ export class Consumer extends EventEmitter {
     public start(): void {
         if (this.stopped) {
             this.stopped = false
+            this.pollLiveness.markStarted()
             this.pollSqs()
             this.startHeartbeat()
+            this.startPollLivenessWatchdog()
         }
     }
 
     public stop(): void {
         this.stopped = true
         this.stopHeartbeat()
+        this.stopPollLivenessWatchdog()
     }
 
     private pollSqs(): void {
@@ -325,9 +356,13 @@ export class Consumer extends EventEmitter {
     }
 
     private async receiveMessage(params: ReceiveMessageRequest): Promise<ReceiveMessageResult> {
+        this.pollLiveness.onPollStarted()
         try {
-            return await this.sqs.send(new ReceiveMessageCommand(params))
+            const result = await this.sqs.send(new ReceiveMessageCommand(params))
+            this.pollLiveness.onPollCompleted()
+            return result
         } catch (err) {
+            this.pollLiveness.onPollCompleted()
             throw toSQSError(err, `SQS receive message failed: ${err.message}`)
         }
     }
@@ -528,6 +563,29 @@ export class Consumer extends EventEmitter {
 
     private stopHeartbeat(): void {
         clearInterval(this.heartbeatTimeout)
+    }
+
+    private startPollLivenessWatchdog(): void {
+        if (!this.pollLivenessWatchdog) {
+            return
+        }
+
+        const maxStaleSeconds = this.pollLivenessWatchdog.maxStaleSeconds ?? 60
+        const checkIntervalMs = this.pollLivenessWatchdog.checkIntervalMs ?? 10_000
+
+        this.pollLivenessWatchdogInterval = setInterval(() => {
+            if (!this.isPollHealthy(maxStaleSeconds)) {
+                this.emit("poll_liveness_stale")
+                this.pollLivenessWatchdog?.onStale()
+            }
+        }, checkIntervalMs)
+    }
+
+    private stopPollLivenessWatchdog(): void {
+        if (this.pollLivenessWatchdogInterval) {
+            clearInterval(this.pollLivenessWatchdogInterval)
+            this.pollLivenessWatchdogInterval = null
+        }
     }
 
     private isBatchProcessing(): boolean {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -114,6 +114,9 @@ export class Consumer extends EventEmitter {
     }
 
     emit<T extends keyof Events>(event: T, ...args: Events[T]) {
+        if (event === "error") {
+            this.pollLiveness.onConsumerError()
+        }
         return super.emit(event, ...args)
     }
 
@@ -129,12 +132,8 @@ export class Consumer extends EventEmitter {
         return !this.stopped
     }
 
-    public getLastPollCompletedAt(): number {
-        return this.pollLiveness.getLastPollCompletedAt()
-    }
-
-    public secondsSincePollCompleted(): number {
-        return this.pollLiveness.secondsSincePollCompleted()
+    public getLastPollActivityAt(): number {
+        return this.pollLiveness.getLastPollActivityAt()
     }
 
     public secondsSincePollActivity(): number {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -115,7 +115,7 @@ export class Consumer extends EventEmitter {
 
     emit<T extends keyof Events>(event: T, ...args: Events[T]) {
         if (event === "error") {
-            this.pollLiveness.onConsumerError()
+            this.pollLiveness.markConsumerError()
         }
         return super.emit(event, ...args)
     }
@@ -132,8 +132,8 @@ export class Consumer extends EventEmitter {
         return !this.stopped
     }
 
-    public getLastPollActivityAt(): number {
-        return this.pollLiveness.getLastPollActivityAt()
+    public getLastPollActivityTimestamp(): number {
+        return this.pollLiveness.getLastPollActivityTimestamp()
     }
 
     public secondsSincePollActivity(): number {
@@ -492,7 +492,7 @@ export class Consumer extends EventEmitter {
                 }),
             )
         } catch (err) {
-            this.emit("error", toSQSError(err, `Error changing visibility timeout: ${err.message}`), message)
+            this.emitConsumerError(toSQSError(err, `Error changing visibility timeout: ${err.message}`), message)
         }
     }
 
@@ -507,7 +507,7 @@ export class Consumer extends EventEmitter {
     private emitError(err: Error, messages: Message[]): void
     private emitError(err: Error, messageOrMessages: Message | Message[]): void {
         if (err.name === SQSError.name) {
-            this.emit("error", err, messageOrMessages)
+            this.emitConsumerError(err, messageOrMessages)
             return
         }
         if (err instanceof TimeoutError) {
@@ -519,6 +519,15 @@ export class Consumer extends EventEmitter {
             return
         }
         this.emit("processing_error", err, messageOrMessages)
+    }
+
+    private emitConsumerError(err: Error): boolean
+    private emitConsumerError(err: Error, messageOrMessages: Message | Message[]): boolean
+    private emitConsumerError(err: Error, messageOrMessages?: Message | Message[]): boolean {
+        if (messageOrMessages === undefined) {
+            return this.emit("error", err)
+        }
+        return this.emit("error", err, messageOrMessages)
     }
 
     private async changeVisibilityTimeoutOfBatch(batch: PendingMessages, timeout: number, elapsedSeconds: number) {
@@ -544,7 +553,7 @@ export class Consumer extends EventEmitter {
         try {
             return await this.sqs.send(new ChangeMessageVisibilityBatchCommand(params))
         } catch (err) {
-            this.emit("error", toSQSError(err, `Error changing visibility timeout batch: ${err.message}`), messages)
+            this.emitConsumerError(toSQSError(err, `Error changing visibility timeout batch: ${err.message}`), messages)
         }
     }
 

--- a/src/liveness.ts
+++ b/src/liveness.ts
@@ -21,11 +21,11 @@ export class PollLiveness {
         this.receiveMessageStartedTimestamp = null
     }
 
-    onPollStarted(): void {
+    markPollStarted(): void {
         this.receiveMessageStartedTimestamp = Date.now()
     }
 
-    onPollCompleted(): void {
+    markPollCompleted(): void {
         this.lastPollActivityTimestamp = Date.now()
         this.receiveMessageStartedTimestamp = null
     }

--- a/src/liveness.ts
+++ b/src/liveness.ts
@@ -2,22 +2,22 @@
 export const DEFAULT_POLL_RECEIVE_TIMEOUT_MS = 35_000
 
 /**
- * Tracks SQS long-poll cycle progress for ALB /ping liveness.
+ * Tracks SQS long-poll activity for ALB /ping liveness.
  * Distinct from visibility-timeout heartbeat (heartbeatInterval on Consumer).
  */
 export class PollLiveness {
-    private lastReceiveMessageCompletedAt: number
+    private lastPollActivityAt: number
     private receiveMessageStartedAt: number | null
     private readonly pollReceiveTimeoutMs: number
 
     constructor(pollReceiveTimeoutMs: number = DEFAULT_POLL_RECEIVE_TIMEOUT_MS) {
         this.pollReceiveTimeoutMs = pollReceiveTimeoutMs
-        this.lastReceiveMessageCompletedAt = Date.now()
+        this.lastPollActivityAt = Date.now()
         this.receiveMessageStartedAt = null
     }
 
     markStarted(): void {
-        this.lastReceiveMessageCompletedAt = Date.now()
+        this.lastPollActivityAt = Date.now()
         this.receiveMessageStartedAt = null
     }
 
@@ -26,29 +26,29 @@ export class PollLiveness {
     }
 
     onPollCompleted(): void {
-        this.lastReceiveMessageCompletedAt = Date.now()
+        this.lastPollActivityAt = Date.now()
         this.receiveMessageStartedAt = null
     }
 
-    getLastPollCompletedAt(): number {
-        return this.lastReceiveMessageCompletedAt
+    onConsumerError(): void {
+        this.lastPollActivityAt = Date.now()
     }
 
-    secondsSincePollCompleted(nowMs: number = Date.now()): number {
-        return Math.floor((nowMs - this.lastReceiveMessageCompletedAt) / 1000)
+    getLastPollActivityAt(): number {
+        return this.lastPollActivityAt
     }
 
     secondsSincePollActivity(nowMs: number = Date.now()): number {
         if (this.receiveMessageStartedAt !== null && nowMs - this.receiveMessageStartedAt > this.pollReceiveTimeoutMs) {
             return Math.floor((nowMs - this.receiveMessageStartedAt) / 1000)
         }
-        return this.secondsSincePollCompleted(nowMs)
+        return Math.floor((nowMs - this.lastPollActivityAt) / 1000)
     }
 
     isPollHealthy(maxStaleSeconds: number = 60, nowMs: number = Date.now()): boolean {
         if (this.receiveMessageStartedAt !== null && nowMs - this.receiveMessageStartedAt > this.pollReceiveTimeoutMs) {
             return false
         }
-        return this.secondsSincePollCompleted(nowMs) <= maxStaleSeconds
+        return this.secondsSincePollActivity(nowMs) <= maxStaleSeconds
     }
 }

--- a/src/liveness.ts
+++ b/src/liveness.ts
@@ -1,0 +1,54 @@
+/** Default long-poll receive timeout; should exceed WaitTimeSeconds plus margin. */
+export const DEFAULT_POLL_RECEIVE_TIMEOUT_MS = 35_000
+
+/**
+ * Tracks SQS long-poll cycle progress for ALB /ping liveness.
+ * Distinct from visibility-timeout heartbeat (heartbeatInterval on Consumer).
+ */
+export class PollLiveness {
+    private lastReceiveMessageCompletedAt: number
+    private receiveMessageStartedAt: number | null
+    private readonly pollReceiveTimeoutMs: number
+
+    constructor(pollReceiveTimeoutMs: number = DEFAULT_POLL_RECEIVE_TIMEOUT_MS) {
+        this.pollReceiveTimeoutMs = pollReceiveTimeoutMs
+        this.lastReceiveMessageCompletedAt = Date.now()
+        this.receiveMessageStartedAt = null
+    }
+
+    markStarted(): void {
+        this.lastReceiveMessageCompletedAt = Date.now()
+        this.receiveMessageStartedAt = null
+    }
+
+    onPollStarted(): void {
+        this.receiveMessageStartedAt = Date.now()
+    }
+
+    onPollCompleted(): void {
+        this.lastReceiveMessageCompletedAt = Date.now()
+        this.receiveMessageStartedAt = null
+    }
+
+    getLastPollCompletedAt(): number {
+        return this.lastReceiveMessageCompletedAt
+    }
+
+    secondsSincePollCompleted(nowMs: number = Date.now()): number {
+        return Math.floor((nowMs - this.lastReceiveMessageCompletedAt) / 1000)
+    }
+
+    secondsSincePollActivity(nowMs: number = Date.now()): number {
+        if (this.receiveMessageStartedAt !== null && nowMs - this.receiveMessageStartedAt > this.pollReceiveTimeoutMs) {
+            return Math.floor((nowMs - this.receiveMessageStartedAt) / 1000)
+        }
+        return this.secondsSincePollCompleted(nowMs)
+    }
+
+    isPollHealthy(maxStaleSeconds: number = 60, nowMs: number = Date.now()): boolean {
+        if (this.receiveMessageStartedAt !== null && nowMs - this.receiveMessageStartedAt > this.pollReceiveTimeoutMs) {
+            return false
+        }
+        return this.secondsSincePollCompleted(nowMs) <= maxStaleSeconds
+    }
+}

--- a/src/liveness.ts
+++ b/src/liveness.ts
@@ -6,47 +6,47 @@ export const DEFAULT_POLL_RECEIVE_TIMEOUT_MS = 35_000
  * Distinct from visibility-timeout heartbeat (heartbeatInterval on Consumer).
  */
 export class PollLiveness {
-    private lastPollActivityAt: number
-    private receiveMessageStartedAt: number | null
+    private lastPollActivityTimestamp: number
+    private receiveMessageStartedTimestamp: number | null
     private readonly pollReceiveTimeoutMs: number
 
     constructor(pollReceiveTimeoutMs: number = DEFAULT_POLL_RECEIVE_TIMEOUT_MS) {
         this.pollReceiveTimeoutMs = pollReceiveTimeoutMs
-        this.lastPollActivityAt = Date.now()
-        this.receiveMessageStartedAt = null
+        this.lastPollActivityTimestamp = Date.now()
+        this.receiveMessageStartedTimestamp = null
     }
 
     markStarted(): void {
-        this.lastPollActivityAt = Date.now()
-        this.receiveMessageStartedAt = null
+        this.lastPollActivityTimestamp = Date.now()
+        this.receiveMessageStartedTimestamp = null
     }
 
     onPollStarted(): void {
-        this.receiveMessageStartedAt = Date.now()
+        this.receiveMessageStartedTimestamp = Date.now()
     }
 
     onPollCompleted(): void {
-        this.lastPollActivityAt = Date.now()
-        this.receiveMessageStartedAt = null
+        this.lastPollActivityTimestamp = Date.now()
+        this.receiveMessageStartedTimestamp = null
     }
 
-    onConsumerError(): void {
-        this.lastPollActivityAt = Date.now()
+    markConsumerError(): void {
+        this.lastPollActivityTimestamp = Date.now()
     }
 
-    getLastPollActivityAt(): number {
-        return this.lastPollActivityAt
+    getLastPollActivityTimestamp(): number {
+        return this.lastPollActivityTimestamp
     }
 
     secondsSincePollActivity(nowMs: number = Date.now()): number {
-        if (this.receiveMessageStartedAt !== null && nowMs - this.receiveMessageStartedAt > this.pollReceiveTimeoutMs) {
-            return Math.floor((nowMs - this.receiveMessageStartedAt) / 1000)
+        if (this.receiveMessageStartedTimestamp !== null && nowMs - this.receiveMessageStartedTimestamp > this.pollReceiveTimeoutMs) {
+            return Math.floor((nowMs - this.receiveMessageStartedTimestamp) / 1000)
         }
-        return Math.floor((nowMs - this.lastPollActivityAt) / 1000)
+        return Math.floor((nowMs - this.lastPollActivityTimestamp) / 1000)
     }
 
     isPollHealthy(maxStaleSeconds: number = 60, nowMs: number = Date.now()): boolean {
-        if (this.receiveMessageStartedAt !== null && nowMs - this.receiveMessageStartedAt > this.pollReceiveTimeoutMs) {
+        if (this.receiveMessageStartedTimestamp !== null && nowMs - this.receiveMessageStartedTimestamp > this.pollReceiveTimeoutMs) {
             return false
         }
         return this.secondsSincePollActivity(nowMs) <= maxStaleSeconds

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,20 @@ export interface BatchProcessingResult {
     failed: Message[]
 }
 
+export type PollLivenessWatchdogOptions = {
+    /**
+     * Maximum seconds since the last completed long-poll before the watchdog fires.
+     * @default 60
+     */
+    maxStaleSeconds?: number
+    /**
+     * How often the watchdog checks poll liveness.
+     * @default 10000
+     */
+    checkIntervalMs?: number
+    onStale: () => void
+}
+
 export type ConsumerOptions = {
     queueUrl: string
     attributeNames?: string[]
@@ -22,6 +36,12 @@ export type ConsumerOptions = {
     pollingWaitTimeMs?: number
     terminateVisibilityTimeout?: boolean
     heartbeatInterval?: number
+    /**
+     * Maximum time a single ReceiveMessage long-poll may run before poll liveness is unhealthy.
+     * @default max(35000, waitTimeSeconds * 1000 + 5000)
+     */
+    pollReceiveTimeoutMs?: number
+    pollLivenessWatchdog?: PollLivenessWatchdogOptions
     sqs?: SQSClient
     region?: string
     handleMessageTimeout?: number
@@ -53,6 +73,7 @@ export interface Events {
     message_batch_received: [Message[]]
     message_batch_processed: [Message[], any]
     batch_processing_error: [Error, Message[]]
+    poll_liveness_stale: []
 }
 
 export type PendingStatus = {

--- a/tests/liveness.spec.ts
+++ b/tests/liveness.spec.ts
@@ -25,10 +25,10 @@ describe("PollLiveness", () => {
         clock.tick(61_000)
 
         assert.equal(liveness.isPollHealthy(60), false)
-        assert.equal(liveness.secondsSincePollCompleted(), 61)
+        assert.equal(liveness.secondsSincePollActivity(), 61)
     })
 
-    it("onPollCompleted resets completed staleness", () => {
+    it("onPollCompleted resets activity staleness", () => {
         const liveness = new PollLiveness(35_000)
 
         clock.tick(50_000)
@@ -37,7 +37,7 @@ describe("PollLiveness", () => {
         clock.tick(50_000)
 
         assert.equal(liveness.isPollHealthy(60), true)
-        assert.equal(liveness.secondsSincePollCompleted(), 50)
+        assert.equal(liveness.secondsSincePollActivity(), 50)
     })
 
     it("becomes unhealthy when receive stays in flight past receiveTimeoutMs", () => {
@@ -59,5 +59,28 @@ describe("PollLiveness", () => {
         clock.tick(50_000)
 
         assert.equal(liveness.isPollHealthy(60), true)
+    })
+
+    it("onConsumerError resets activity staleness", () => {
+        const liveness = new PollLiveness(35_000)
+
+        clock.tick(50_000)
+        liveness.onConsumerError()
+        clock.tick(50_000)
+
+        assert.equal(liveness.isPollHealthy(60), true)
+        assert.equal(liveness.secondsSincePollActivity(), 50)
+        assert.equal(liveness.getLastPollActivityAt(), Date.parse("2026-06-04T12:00:50.000Z"))
+    })
+
+    it("onConsumerError does not hide a hung receive", () => {
+        const liveness = new PollLiveness(35_000)
+
+        liveness.onPollStarted()
+        clock.tick(36_000)
+        liveness.onConsumerError()
+
+        assert.equal(liveness.isPollHealthy(60), false)
+        assert.equal(liveness.secondsSincePollActivity(), 36)
     })
 })

--- a/tests/liveness.spec.ts
+++ b/tests/liveness.spec.ts
@@ -1,0 +1,63 @@
+import { assert } from "chai"
+import * as sinon from "sinon"
+import { PollLiveness } from "../src/liveness"
+
+describe("PollLiveness", () => {
+    let clock: sinon.SinonFakeTimers
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers(new Date("2026-06-04T12:00:00.000Z"))
+    })
+
+    afterEach(() => {
+        clock.restore()
+    })
+
+    it("starts healthy after markStarted", () => {
+        const liveness = new PollLiveness(35_000)
+
+        assert.equal(liveness.isPollHealthy(60), true)
+    })
+
+    it("becomes unhealthy when no poll completes within maxStaleSeconds", () => {
+        const liveness = new PollLiveness(35_000)
+
+        clock.tick(61_000)
+
+        assert.equal(liveness.isPollHealthy(60), false)
+        assert.equal(liveness.secondsSincePollCompleted(), 61)
+    })
+
+    it("onPollCompleted resets completed staleness", () => {
+        const liveness = new PollLiveness(35_000)
+
+        clock.tick(50_000)
+        liveness.onPollStarted()
+        liveness.onPollCompleted()
+        clock.tick(50_000)
+
+        assert.equal(liveness.isPollHealthy(60), true)
+        assert.equal(liveness.secondsSincePollCompleted(), 50)
+    })
+
+    it("becomes unhealthy when receive stays in flight past receiveTimeoutMs", () => {
+        const liveness = new PollLiveness(35_000)
+
+        liveness.onPollStarted()
+        clock.tick(36_000)
+
+        assert.equal(liveness.isPollHealthy(60), false)
+        assert.equal(liveness.secondsSincePollActivity(), 36)
+    })
+
+    it("completing receive clears in-flight unhealthy state", () => {
+        const liveness = new PollLiveness(35_000)
+
+        liveness.onPollStarted()
+        clock.tick(20_000)
+        liveness.onPollCompleted()
+        clock.tick(50_000)
+
+        assert.equal(liveness.isPollHealthy(60), true)
+    })
+})

--- a/tests/liveness.spec.ts
+++ b/tests/liveness.spec.ts
@@ -61,24 +61,24 @@ describe("PollLiveness", () => {
         assert.equal(liveness.isPollHealthy(60), true)
     })
 
-    it("onConsumerError resets activity staleness", () => {
+    it("markConsumerError resets activity staleness", () => {
         const liveness = new PollLiveness(35_000)
 
         clock.tick(50_000)
-        liveness.onConsumerError()
+        liveness.markConsumerError()
         clock.tick(50_000)
 
         assert.equal(liveness.isPollHealthy(60), true)
         assert.equal(liveness.secondsSincePollActivity(), 50)
-        assert.equal(liveness.getLastPollActivityAt(), Date.parse("2026-06-04T12:00:50.000Z"))
+        assert.equal(liveness.getLastPollActivityTimestamp(), Date.parse("2026-06-04T12:00:50.000Z"))
     })
 
-    it("onConsumerError does not hide a hung receive", () => {
+    it("markConsumerError does not hide a hung receive", () => {
         const liveness = new PollLiveness(35_000)
 
         liveness.onPollStarted()
         clock.tick(36_000)
-        liveness.onConsumerError()
+        liveness.markConsumerError()
 
         assert.equal(liveness.isPollHealthy(60), false)
         assert.equal(liveness.secondsSincePollActivity(), 36)

--- a/tests/liveness.spec.ts
+++ b/tests/liveness.spec.ts
@@ -28,12 +28,12 @@ describe("PollLiveness", () => {
         assert.equal(liveness.secondsSincePollActivity(), 61)
     })
 
-    it("onPollCompleted resets activity staleness", () => {
+    it("markPollCompleted resets activity staleness", () => {
         const liveness = new PollLiveness(35_000)
 
         clock.tick(50_000)
-        liveness.onPollStarted()
-        liveness.onPollCompleted()
+        liveness.markPollStarted()
+        liveness.markPollCompleted()
         clock.tick(50_000)
 
         assert.equal(liveness.isPollHealthy(60), true)
@@ -43,7 +43,7 @@ describe("PollLiveness", () => {
     it("becomes unhealthy when receive stays in flight past receiveTimeoutMs", () => {
         const liveness = new PollLiveness(35_000)
 
-        liveness.onPollStarted()
+        liveness.markPollStarted()
         clock.tick(36_000)
 
         assert.equal(liveness.isPollHealthy(60), false)
@@ -53,9 +53,9 @@ describe("PollLiveness", () => {
     it("completing receive clears in-flight unhealthy state", () => {
         const liveness = new PollLiveness(35_000)
 
-        liveness.onPollStarted()
+        liveness.markPollStarted()
         clock.tick(20_000)
-        liveness.onPollCompleted()
+        liveness.markPollCompleted()
         clock.tick(50_000)
 
         assert.equal(liveness.isPollHealthy(60), true)
@@ -76,7 +76,7 @@ describe("PollLiveness", () => {
     it("markConsumerError does not hide a hung receive", () => {
         const liveness = new PollLiveness(35_000)
 
-        liveness.onPollStarted()
+        liveness.markPollStarted()
         clock.tick(36_000)
         liveness.markConsumerError()
 


### PR DESCRIPTION
Abstrahování health checku consumera: https://github.com/FigurePOS/fgr-service-delivery/blob/master/src/api/ping/healthCheck.ts a https://github.com/FigurePOS/fgr-service-delivery/blob/63b1024f44e2d635456fcab404c8298289e87532/src/events/worker.ts#L46-L58

~S jednou změnou v chování. Tak jak to je všude teď naimplementovaný, tak se posílá heartbeat (resp. potvrzuje liveness consumera) i v případě chyby (viz. `consumer.on("error")` v `events/worker.ts`). Což imho nedává moc smysl. Pokud by se dostal do stavu, že bude jen emitovat chyby, tak to za současnýho chování bude udržovat ping při živote.~